### PR TITLE
Fix user ID extraction

### DIFF
--- a/extractAmazonReviews-DivLayout.pl
+++ b/extractAmazonReviews-DivLayout.pl
@@ -126,7 +126,7 @@ sub extract {
 		   $helpfulYes =  ($1, $2)[$1 > $2];
 		}
 		my $userId = "ANONYMOUS";
-		if($block =~ m#profile\/(.*?)["/].*?\<\/div\>.*?\<\/div\>.#gs) {
+		if($block =~ /profile\/(.*?)\//) {
 			$userId = $1;
 		}
 


### PR DESCRIPTION
There was an error. User ID was always set to ANONYMOUS in final CSV.
The change fixes it.
