### PR TITLE
Check if page exists before redownloading

### DIFF
--- a/downloadAmazonReviews.pl
+++ b/downloadAmazonReviews.pl
@@ -21,7 +21,7 @@
 # output: a directory ./amazonreviews/<domain>/<ID> is created for each product ID; HTML files containing reviews are downloaded and saved in each directory.
 
 use strict;
-use LWP::UserAgent; 
+use LWP::UserAgent;
 use HTTP::Request;
 
 $| = 1; #autoflush
@@ -54,6 +54,13 @@ while($id  = shift) {
 	my $lastPage = 1;
     while($page<=$lastPage) {
 
+		# If page already downloaded then skip
+		# but make sure first iteration runs
+		if(-e "$dir/$page" && $lastPage != 1) {
+			++$page;
+			next;
+		}
+
 		my $url = $urlPart1.$id.$urlPart2.$page.$urlPart3;
 
 		print $url;
@@ -72,7 +79,7 @@ while($id  = shift) {
 					$lastPage = $val;
 				}
 			}
-			
+
 			if(open(CONTENTFILE, ">./$dir/$page")) {
 				binmode(CONTENTFILE, ":utf8");
 				print CONTENTFILE $content;
@@ -82,7 +89,7 @@ while($id  = shift) {
 			else {
 				print "failed\t$domain\t$id\t$page\t$lastPage\n";
 			}
-			
+
 			if($sleepTime>0) {
 				--$sleepTime;
 			}

--- a/downloadAmazonReviews.pl
+++ b/downloadAmazonReviews.pl
@@ -73,11 +73,20 @@ while($id  = shift) {
 			print " GOTIT\n";
 			my $content = $response->decoded_content;
 
+			my $matched = 0;
 			while($content =~ m#cm_cr_arp_d_paging_btm_([0-9]+)#gs ) {
 				my $val = $1+0;
 				if($val>$lastPage) {
 					$lastPage = $val;
 				}
+
+				$matched = 1
+			}
+
+			# Try again if no usable content was returned
+			if(!$matched) {
+			    print "Unusable results, trying again\n";
+			    next;
 			}
 
 			if(open(CONTENTFILE, ">./$dir/$page")) {


### PR DESCRIPTION
If the operation times out restarting the script will cause it to re-download all files again from the start. First change checks if a page has been downloaded first. The first iteration still occurs to get the metadata (last page).

Second change ensures a usable page was returned, otherwise last page never get updated and process ends on the first page without actual reviews.
